### PR TITLE
Initializing upstream branch in empty repositories

### DIFF
--- a/entrypoint.php
+++ b/entrypoint.php
@@ -89,6 +89,13 @@ if ($changedFiles) {
     note('Adding git commit');
     exec_with_output_print('git add .');
 
+    // The target repository might be empty (e.g. first commit)
+    exec('git rev-list -n 1 --all', $latestCommitHash);
+    if (!$latestCommitHash) {
+        note('The target repository is empty, creating an upstream branch');
+        exec_with_output_print('git branch -M ' . $config->getBranch());
+    }
+
     $message = sprintf('Pushing git commit with "%s" message to "%s"', $commitMessage, $config->getBranch());
     note($message);
 


### PR DESCRIPTION
While working on #20 I run into an issue with empty target repositories: brand new repositories are empty and don't have any commit, but his action fails pushing changes those kind of repositories.

**I ended up with this solution:**
The command `git rev-list -n 1 --all` outputs the latest commit hash or nothing when there is no commit yet. Testing the result of this command allows us to run a `git branch -M TARGET_BRANCH` on the repository before trying to commit any changes.

Here you can see a successful run on a brand new target repository: https://github.com/liarco/split-action-test-monorepo/runs/3768603331?check_suite_focus=true#step:4:63

Thank you for your time.